### PR TITLE
ZeroMQ socket handling cleanup to avoid shutdown hang

### DIFF
--- a/doc/sdk/docker.rst
+++ b/doc/sdk/docker.rst
@@ -131,9 +131,9 @@ The following Docker commands are useful once the container has been created.
                 Running application ...
                 On 'run' callback.
                 On 'load configuration' callback.
-                Connecting to API URL: https://172.17.0.3:443
-                Connecting to zeromq URL: tcp://172.17.0.3:50000
-                Waiting for zeromq notifications: ['misp_json_event']
+                Connecting to MISP API URL: https://172.17.0.3:443
+                Connecting to MISP ZeroMQ URL: tcp://172.17.0.3:50000
+                Subscribing to MISP ZeroMQ topic: misp_json_event ...
                 Incoming message configuration: queueSize=1000, threadCount=10
                 Message callback configuration: queueSize=1000, threadCount=10
                 Attempting to connect to DXL fabric ...

--- a/doc/sdk/running.rst
+++ b/doc/sdk/running.rst
@@ -28,9 +28,9 @@ configuration should appear similar to the following:
         Running application ...
         On 'run' callback.
         On 'load configuration' callback.
-        Connecting to API URL: https://172.17.0.3:443
-        Connecting to zeromq URL: tcp://172.17.0.3:50000
-        Waiting for zeromq notifications: ['misp_json_event']
+        Connecting to MISP API URL: https://172.17.0.3:443
+        Connecting to MISP ZeroMQ URL: tcp://172.17.0.3:50000
+        Subscribing to MISP ZeroMQ topic: misp_json_event ...
         Incoming message configuration: queueSize=1000, threadCount=10
         Message callback configuration: queueSize=1000, threadCount=10
         Attempting to connect to DXL fabric ...

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -67,8 +67,8 @@ class Sample(unittest.TestCase):
         return mock_print
 
     def run_sample(self, sample_file, add_request_mocks_fn=None):
-        context = zmq.Context()
-        with dxlmispservice.MispService("sample") as app:
+        with zmq.Context() as context, \
+                dxlmispservice.MispService("sample") as app:
             config = ConfigParser()
             config.read(app._app_config_path)
 
@@ -103,6 +103,7 @@ class Sample(unittest.TestCase):
                             zmq.PUB) as zmq_socket:  # pylint: disable=no-member
                     zmq_port = zmq_socket.bind_to_random_port("tcp://" +
                                                               self._TEST_HOSTNAME)
+                    zmq_socket.setsockopt(zmq.LINGER, 0)  # pylint: disable=no-member
 
                     config.set(
                         dxlmispservice.MispService._GENERAL_CONFIG_SECTION,


### PR DESCRIPTION
Previously, unit tests intermittently failed due to a hang when running
in Travis CI - frequently on Python 3.4. The hang was due to the
poll() for ZeroMQ MISP notifications being done on a background thread
not being interrupted and allowing the thread to be terminated as the
MISP DXL service was shutting down.

In this commit, a separate PULL socket associated with an internal PUSH
socket is registered with the ZeroMQ poller. During DXL service
shutdown, a message is sent to the PUSH socket, allowing activity on the
PULL socket to interrupt the blocking ZeroMQ poll() and stop the poll
thread.

This follows the "command" socket pattern described in the pyzmq polling
docs at:

https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/multisocket/zmqpoller.html

This commit also includes some additional logic for freeing the ZeroMQ
context and sockets during shutdown.